### PR TITLE
Fix GPG signature errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ None
 Available variables are listed below, along with default values:
 
     percona_arch: noarch
-    percona_baseurl: "https://www.percona.com/redir/downloads/{{ percona_pkg }}/redhat/{{ percona_ver }}-{{ percona_rel }}"
+    percona_baseurl: "https://repo.percona.com/yum"
     percona_disablerepo: []
     percona_enablerepo: []
-    percona_fetch: "{{ percona_baseurl }}/{{ percona_release }}.{{ percona_arch }}.rpm"
+    percona_fetch: >-
+      {{ percona_baseurl }}/{{ percona_release }}.{{ percona_arch }}.rpm
     percona_packages: []
     percona_pkg: percona-release
-    percona_rel: 6
+    percona_rel: 9
     percona_release: "{{ percona_pkg }}-{{ percona_ver }}-{{ percona_rel }}"
     percona_repository_experimental_basearch: false
     percona_repository_experimental_noarch: false
@@ -32,7 +33,7 @@ Available variables are listed below, along with default values:
     percona_repository_testing_basearch: false
     percona_repository_testing_noarch: false
     percona_repository_testing_source: false
-    percona_ver: 0.1
+    percona_ver: 1.0
 
 All repositories are disabled by default.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,8 @@ percona_arch: noarch
 percona_baseurl: "https://repo.percona.com/yum"
 percona_disablerepo: []
 percona_enablerepo: []
-percona_fetch: "{{ percona_baseurl }}/{{ percona_release }}.{{ percona_arch }}.rpm"
+percona_fetch: >-
+  {{ percona_baseurl }}/{{ percona_release }}.{{ percona_arch }}.rpm
 percona_packages: []
 percona_pkg: percona-release
 percona_rel: 9

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
 percona_arch: noarch
-percona_baseurl: "https://www.percona.com/redir/downloads/{{ percona_pkg }}/redhat/{{ percona_ver }}-{{ percona_rel }}"
+percona_baseurl: "https://repo.percona.com/yum"
 percona_disablerepo: []
 percona_enablerepo: []
 percona_fetch: "{{ percona_baseurl }}/{{ percona_release }}.{{ percona_arch }}.rpm"
 percona_packages: []
 percona_pkg: percona-release
-percona_rel: 6
+percona_rel: 9
 percona_release: "{{ percona_pkg }}-{{ percona_ver }}-{{ percona_rel }}"
 percona_repository_experimental_basearch: false
 percona_repository_experimental_noarch: false
@@ -17,5 +17,5 @@ percona_repository_release_source: false
 percona_repository_testing_basearch: false
 percona_repository_testing_noarch: false
 percona_repository_testing_source: false
-percona_ver: 0.1
+percona_ver: 1.0
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,10 +20,9 @@
   tags: percona
   become: true
   yum:
-    name: "{{ item }}"
+    name: "{{ percona_tempfile.path }}"
     state: present
   register: percona_yum
-  with_items: "{{ percona_tempfile.path }}"
   when: percona_get_url is success
 
 - name: Attempting to purge temporary package from the filesystem

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   tags: percona
   get_url:
     dest: "{{ percona_tempfile.path }}"
-    force: yes
+    force: true
     url: "{{ percona_fetch }}"
   register: percona_get_url
   when: percona_tempfile is success
@@ -45,7 +45,8 @@
     group: root
     mode: 0644
   with_items:
-    - { src: percona-release.repo.j2, dst: /etc/yum.repos.d/percona-release.repo }
+    - src: percona-release.repo.j2
+      dst: /etc/yum.repos.d/percona-release.repo
   when: percona_yum is success
 
 - name: Ensure that the percona gpg keys are installed


### PR DESCRIPTION
Percona has updated their GPG key and this was causing signature errors installing packages signed by the new key.

```    failed: [instance] (item=Percona-Server-tokudb-56) => {"changed": true, "msg": "warning: /var/cache/yum/x86_64/7/percona-release-x86_64/packages/jemalloc-3.6.0-1.el7.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 8507efa5: NOKEY\n\n\nThe GPG keys listed for the \"Percona-Release YUM repository - x86_64\" repository are already installed but they are not correct for this package.\nCheck that the correct key URLs are configured for this repository.\n\n\n Failing package is: jemalloc-3.6.0-1.el7.x86_64\n GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Percona\n\n", "obsoletes": {"grub2": {"dist": "x86_64", "repo": "@anaconda", "version": "1:2.02-0.65.el7.centos.2"}, "grub2-tools": {"dist": "x86_64", "repo": "@anaconda", "version": "1:2.02-0.65.el7.centos.2"}}, "percona_pkg": "Percona-Server-tokudb-56", "rc": 1, "results": ["Loaded plugins: fastestmirror, versionlock\nLoading mirror speeds from cached hostfile\n * base: mirror.genesishosting.com\n * extras: mirror.dal10.us.leaseweb.net\n * updates: mirror.mobap.edu\nExcluding 4 updates due to versionlock (use \"yum versionlock status\" to show them)\nResolving Dependencies\n--> Running transaction check\n---> Package Percona-Server-tokudb-56.x86_64 0:5.6.36-rel82.1.el7 will be installed\n--> Processing Dependency: jemalloc >= 3.3.0 for package: Percona-Server-tokudb-56-5.6.36-rel82.1.el7.x86_64\n--> Running transaction check\n---> Package jemalloc.x86_64 0:3.6.0-1.el7 will be installed\n--> Finished Dependency Resolution\n\nDependencies```

Moved to direct download from repo.percona.com since there are not any redirects to specific percona-release versions on www.percon.com/redir.

